### PR TITLE
Custom filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,10 @@ Principles of a change log, excerpted from [Keep a Changelog](http://keepachange
   - Monster;
   - Post;
   - Non-Epic Spell.
-* Layouts' tutorial.
+* Layouts tutorial.
+* Custom filters:
+  - `PrettyNumberFilter` for adding thousands separators;
+  - `AddSignFilter` for prepending `+` on positive modifiers.
 
 ### Change
 * Bump `nokogiri` to `>= 1.10.4`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Principles of a change log, excerpted from [Keep a Changelog](http://keepachange
 * Custom filters:
   - `AbilityModFilter` for appending modifiers to ability scores;
   - `AddSignFilter` for prepending `+` on positive modifiers;
+  - `PluralizeFilter` for appending the singular or plural word, depending on the number given (the code must list both forms of the word);
   - `PrettyNumberFilter` for adding thousands separators.
 
 ### Change

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,8 +54,9 @@ Principles of a change log, excerpted from [Keep a Changelog](http://keepachange
   - Non-Epic Spell.
 * Layouts tutorial.
 * Custom filters:
-  - `PrettyNumberFilter` for adding thousands separators;
-  - `AddSignFilter` for prepending `+` on positive modifiers.
+  - `AbilityModFilter` for appending modifiers to ability scores;
+  - `AddSignFilter` for prepending `+` on positive modifiers;
+  - `PrettyNumberFilter` for adding thousands separators.
 
 ### Change
 * Bump `nokogiri` to `>= 1.10.4`.

--- a/_drafts/monster_template.md
+++ b/_drafts/monster_template.md
@@ -17,13 +17,13 @@ monster:
     hp        : 858
     hd        : 48d10 + 594
   speed       : 20ft
-  initiative  : '+7'
+  initiative  : +7
   space       : 30ft
   reach       : 20ft
   saves:
-    fort      : '+38'
-    ref       : '+29'
-    will      : '+20'
+    fort      : +38
+    ref       : +29
+    will      : +20
   abilities:
     str       : 45 (+17)
     dex       : 16 (+3)

--- a/_drafts/monster_template.md
+++ b/_drafts/monster_template.md
@@ -25,12 +25,12 @@ monster:
     ref       : +29
     will      : +20
   abilities:
-    str       : 45 (+17)
-    dex       : 16 (+3)
-    con       : 35 (+12)
-    int       : 3 (-4)
-    wis       : 14 (+2)
-    cha       : 14 (+2)
+    str       : 45
+    dex       : 16
+    con       : 35
+    int       : 3
+    wis       : 14
+    cha       : 14
   skills      : Listen +17, Search +9, Spot +17, Survival +14 (+16 following tracks)
   feats       : Alertness, Awesome Blow, Blind-Fight, Cleave, Combat Reflexes, Dodge, Great Cleave, Improved Bull Rush, Improved Initiative, Iron Will, Power Attack, Toughness (6)
   cr          : 20

--- a/_layouts/adventure.html
+++ b/_layouts/adventure.html
@@ -14,7 +14,7 @@ layout: default
 <div class="four columns">
   <blockquote class="meta">
     <h5>{{ page.adventure.name | default: 'Adventure Name' }}</h5>
-    <p class="subtitle">An adventure for {{ page.adventure.char-num | default: 4 }} player character{% if page.adventure.char-num > 1 %}s{% endif %} of {% if page.adventure.lvl.range %}levels {{ page.adventure.lvl.min }} through {{ page.adventure.lvl.max }}{% else %}{{ page.adventure.lvl.lvl }} level{% endif %}.</p>
+    <p class="subtitle">An adventure for {{ page.adventure.char-num | default: 4 | pluralize: 'player character', 'player characters' }} of {% if page.adventure.lvl.range %}levels {{ page.adventure.lvl.min }} through {{ page.adventure.lvl.max }}{% else %}{{ page.adventure.lvl.lvl }} level{% endif %}.</p>
     <p><strong>Max XP:</strong> {{ page.adventure.max-xp | pretty_number }} xp</p>
     <p><strong>Max Gold:</strong> {{ page.adventure.max-gp | pretty_number }} gp</p>
     <p><strong>&#35; Encounters:</strong> {{ page.adventure.max-xp }} xp</p>

--- a/_layouts/adventure.html
+++ b/_layouts/adventure.html
@@ -15,8 +15,8 @@ layout: default
   <blockquote class="meta">
     <h5>{{ page.adventure.name | default: 'Adventure Name' }}</h5>
     <p class="subtitle">An adventure for {{ page.adventure.char-num | default: 4 }} player character{% if page.adventure.char-num > 1 %}s{% endif %} of {% if page.adventure.lvl.range %}levels {{ page.adventure.lvl.min }} through {{ page.adventure.lvl.max }}{% else %}{{ page.adventure.lvl.lvl }} level{% endif %}.</p>
-    <p><strong>Max XP:</strong> {{ page.adventure.max-xp }} xp</p>
-    <p><strong>Max Gold:</strong> {{ page.adventure.max-gp }} gp</p>
+    <p><strong>Max XP:</strong> {{ page.adventure.max-xp | pretty_number }} xp</p>
+    <p><strong>Max Gold:</strong> {{ page.adventure.max-gp | pretty_number }} gp</p>
     <p><strong>&#35; Encounters:</strong> {{ page.adventure.max-xp }} xp</p>
     <p><strong>Type:</strong> {{ page.adventure.type }}</p>
     {% if page.adventure.questline %}

--- a/_layouts/monster.html
+++ b/_layouts/monster.html
@@ -42,7 +42,7 @@ layout: default
           <!-- property line -->
           <div class="property-line">
             <h4>Initiative</h4>
-            <p>{{ page.monster.initiative | default: '+7' }}</p>
+            <p>{{ page.monster.initiative | default: 7 | add_sign }}</p>
           </div>
           <!-- property line -->
           <div class="property-line">
@@ -57,7 +57,7 @@ layout: default
           <!-- property line -->
           <div class="property-line last">
             <h4>Saves</h4>
-            <p>Fort {{ page.monster.saves.fort | default: '+38' }}, Ref {{ page.monster.saves.ref | default: '+29' }}, Will {{ page.monster.saves.will | default: '+20' }}</p>
+            <p>Fort {{ page.monster.saves.fort | default: 38 | add_sign }}, Ref {{ page.monster.saves.ref | default: 29 | add_sign }}, Will {{ page.monster.saves.will | default: 20 | add_sign }}</p>
           </div>
           <!-- property line -->
           <svg height="5" width="100%" class="tapered-rule">

--- a/_layouts/monster.html
+++ b/_layouts/monster.html
@@ -32,7 +32,7 @@ layout: default
           <!-- property line -->
           <div class="property-line">
             <h4>Hit Points</h4>
-            <p>{{ page.monster.hp.hp | default: '858' }}hp ({{ page.monster.hp.hd | default: '48d10 + 594' }})</p>
+            <p>{{ page.monster.hp.hp | default: '858' | pretty_number }}hp ({{ page.monster.hp.hd | default: '48d10 + 594' }})</p>
           </div>
           <!-- property line -->
           <div class="property-line">

--- a/_layouts/monster.html
+++ b/_layouts/monster.html
@@ -66,32 +66,32 @@ layout: default
           <div class="abilities">
             <div class="ability-strength">
               <h4>STR</h4>
-              <p>{{ page.monster.abilities.str | default: '45 (+17)' }}</p>
+              <p>{{ page.monster.abilities.str | default: 45 | ability }}</p>
             </div>
             <!-- ability strength -->
             <div class="ability-dexterity">
               <h4>DEX</h4>
-              <p>{{ page.monster.abilities.dex | default: '16 (+3)' }}</p>
+              <p>{{ page.monster.abilities.dex | default: 16 | ability }}</p>
             </div>
             <!-- ability dexterity -->
             <div class="ability-constitution">
               <h4>CON</h4>
-              <p>{{ page.monster.abilities.con | default: '35 (+12)' }}</p>
+              <p>{{ page.monster.abilities.con | default: 35 | ability }}</p>
             </div>
             <!-- ability constitution -->
             <div class="ability-intelligence">
               <h4>INT</h4>
-              <p>{{ page.monster.abilities.int | default: '3 (-4)' }}</p>
+              <p>{{ page.monster.abilities.int | default: 3 | ability }}</p>
             </div>
             <!-- ability intelligence -->
             <div class="ability-wisdom">
               <h4>WIS</h4>
-              <p>{{ page.monster.abilities.wis | default: '14 (+2)' }}</p>
+              <p>{{ page.monster.abilities.wis | default: 14 | ability }}</p>
             </div>
             <!-- ability wisdom -->
             <div class="ability-charisma">
               <h4>CHA</h4>
-              <p>{{ page.monster.abilities.cha | default: '14 (+2)' }}</p>
+              <p>{{ page.monster.abilities.cha | default: 14 | ability }}</p>
             </div>
             <!-- ability charisma -->
           </div>

--- a/_plugins/ability.rb
+++ b/_plugins/ability.rb
@@ -1,0 +1,10 @@
+module Jekyll
+  module AbilityModFilter
+    def ability(input)
+      mod = (input - 10) / 2
+      return input.to_s + " (" + (mod < 0 ? mod.to_s : "+" + mod.to_s) + ")"
+    end
+  end
+end
+
+Liquid::Template.register_filter(Jekyll::AbilityModFilter)

--- a/_plugins/add-sign.rb
+++ b/_plugins/add-sign.rb
@@ -1,0 +1,9 @@
+module Jekyll
+  module AddSignFilter
+    def add_sign(input)
+      return input < 0 ? input.to_s : "+" + input.to_s
+    end
+  end
+end
+
+Liquid::Template.register_filter(Jekyll::AddSignFilter)

--- a/_plugins/number.rb
+++ b/_plugins/number.rb
@@ -1,0 +1,9 @@
+module Jekyll
+  module PrettyNumberFilter
+    def pretty_number(input)
+      return input.to_s.reverse.gsub(/(\d{3})(?=\d)/, '\\1,').reverse
+    end
+  end
+end
+
+Liquid::Template.register_filter(Jekyll::PrettyNumberFilter)

--- a/_plugins/pluralize.rb
+++ b/_plugins/pluralize.rb
@@ -1,0 +1,9 @@
+module Jekyll
+  module PluralizeFilter
+    def pluralize(input, singular, plural)
+      return input.to_s + " " + (input == 1.abs ? singular.to_s : plural.to_s)
+    end
+  end
+end
+
+Liquid::Template.register_filter(Jekyll::PluralizeFilter)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name"                         : "Grimoire",
-  "version"                      : "0.17.12",
+  "version"                      : "0.18.12",
   "description"                  : "A jekyll quasi-wiki for RPG-oriented worldbuilding.",
   "license"                      : "CC-BY-SA-4.0",
   "private"                      : false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name"                         : "Grimoire",
-  "version"                      : "0.18.12",
+  "version"                      : "0.19.12",
   "description"                  : "A jekyll quasi-wiki for RPG-oriented worldbuilding.",
   "license"                      : "CC-BY-SA-4.0",
   "private"                      : false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name"                         : "Grimoire",
-  "version"                      : "0.15.12",
+  "version"                      : "0.16.12",
   "description"                  : "A jekyll quasi-wiki for RPG-oriented worldbuilding.",
   "license"                      : "CC-BY-SA-4.0",
   "private"                      : false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name"                         : "Grimoire",
-  "version"                      : "0.16.12",
+  "version"                      : "0.17.12",
   "description"                  : "A jekyll quasi-wiki for RPG-oriented worldbuilding.",
   "license"                      : "CC-BY-SA-4.0",
   "private"                      : false,


### PR DESCRIPTION
Create a handful of custom [Liquid](https://help.shopify.com/en/themes/liquid) filters.

- **Added:**
  - `AbilityModFilter` for appending modifiers to ability scores;
  - `AddSignFilter` for prepending `+` on positive modifiers;
  - `PluralizeFilter` for appending the singular or plural word, depending on the number given (the code must list both forms of the word);
  - `PrettyNumberFilter` for adding thousands separators.